### PR TITLE
Fixed RN 0.47 compatibility by removing @override from createJSModules

### DIFF
--- a/android/src/main/java/io/tradle/react/LocalAuthPackage.java
+++ b/android/src/main/java/io/tradle/react/LocalAuthPackage.java
@@ -17,7 +17,8 @@ public class LocalAuthPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new LocalAuthModule(reactContext));
     }
 
-    @Override
+    // @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
Could not remove the function as it would break RN <0.47